### PR TITLE
Minimal governance

### DIFF
--- a/contracts/bridge/src/test/utils/Math.p.sol
+++ b/contracts/bridge/src/test/utils/Math.p.sol
@@ -32,13 +32,4 @@ contract MathTest is Math {
         uint y = log_2(x);
         assert(2**(y-1) < x && x <= 2**y);
     }
-
-    function property_max(uint x, uint y) public pure {
-        uint z = _max(x, y);
-        if (z == x) {
-            assert(z >= y);
-        } {
-            assert(z >= x);
-        }
-    }
 }

--- a/contracts/bridge/src/test/utils/Math.t.sol
+++ b/contracts/bridge/src/test/utils/Math.t.sol
@@ -74,15 +74,4 @@ contract MathTest is DSTest, Math {
         uint y = log_2(x);
         assertTrue(2**(y-1) < x && x <= 2**y);
     }
-
-    function prove_max(uint x, uint y) public {
-        uint z = _max(x, y);
-        if (z == x) {
-            assertGe(z, y);
-        } else if (z == y) {
-            assertGe(z, x);
-        } else {
-            fail();
-        }
-    }
 }

--- a/contracts/bridge/src/truth/common/SerialLaneStorageVerifier.sol
+++ b/contracts/bridge/src/truth/common/SerialLaneStorageVerifier.sol
@@ -70,8 +70,11 @@ abstract contract SerialLaneStorageVerifier is IVerifier, SourceChain, TargetCha
         setter = msg.sender;
     }
 
+    /// Registry a pair of out lane and in lane, could not remove them
     function registry(uint32 bridgedChainPosition, uint32 outboundPosition, address outbound, uint32 inboundPositon, address inbound) external onlySetter {
         require(bridgedChainPosition != THIS_CHAIN_POSITION, "invalid_chain_pos");
+        require(lanes[bridgedChainPosition][outboundPosition] == address(0), "!empty");
+        require(lanes[bridgedChainPosition][inboundPositon] == address(0), "!empty");
         lanes[bridgedChainPosition][outboundPosition] = outbound;
         lanes[bridgedChainPosition][inboundPositon] = inbound;
         emit Registry(bridgedChainPosition, outboundPosition, outbound);

--- a/contracts/bridge/src/truth/darwinia/ChainMessageCommitter.sol
+++ b/contracts/bridge/src/truth/darwinia/ChainMessageCommitter.sol
@@ -44,7 +44,6 @@ contract ChainMessageCommitter is MessageCommitter {
     }
 
     constructor() {
-        maxChainPosition = THIS_CHAIN_POSITION;
         setter = msg.sender;
     }
 

--- a/contracts/bridge/src/truth/darwinia/LaneMessageCommitter.sol
+++ b/contracts/bridge/src/truth/darwinia/LaneMessageCommitter.sol
@@ -71,21 +71,7 @@ contract LaneMessageCommitter is MessageCommitter {
         setter = _setter;
     }
 
-    /// @dev Change lane address of the given positon
-    /// @notice Only could be called by setter
-    /// @param pos The given positon
-    /// @param lane New lane address of the given positon
-    function changeLane(uint256 pos, address lane) external onlySetter {
-        require(laneOf[pos] != address(0), "!exist");
-        (uint32 _thisChainPosition, uint32 _thisLanePosition, uint32 _bridgedChainPosition, ) = ILane(lane).getLaneInfo();
-        require(THIS_CHAIN_POSITION == _thisChainPosition, "!thisChainPosition");
-        require(BRIDGED_CHAIN_POSITION == _bridgedChainPosition, "!bridgedChainPosition");
-        require(pos == _thisLanePosition, "!thisLanePosition");
-        laneOf[pos] = lane;
-        emit ChangeLane(pos, lane);
-    }
-
-    /// @dev Registry a pair of out lane and in lane
+    /// @dev Registry a pair of out lane and in lane, could not remove them
     /// @notice Only could be called by setter
     /// @param outboundLane Address of outbound lane
     /// @param inboundLane Address of inbound lane

--- a/contracts/bridge/src/truth/eth/EthereumSerialLaneVerifier.sol
+++ b/contracts/bridge/src/truth/eth/EthereumSerialLaneVerifier.sol
@@ -23,22 +23,13 @@ import "../../spec/ChainMessagePosition.sol";
 import "../../interfaces/ILightClient.sol";
 
 contract EthereumSerialLaneVerifier is SerialLaneStorageVerifier {
-    ILightClient private light_client;
+    address public immutable LIGHT_CLIENT;
 
-    constructor(address lightclient) SerialLaneStorageVerifier(uint32(ChainMessagePosition.ETH), 0, 1, 2) {
-        light_client = ILightClient(lightclient);
+    constructor(address light_client) SerialLaneStorageVerifier(uint32(ChainMessagePosition.ETH), 0, 1, 2) {
+        LIGHT_CLIENT = light_client;
     }
 
     function state_root() public view override returns (bytes32) {
-        return light_client.merkle_root();
+        return ILightClient(LIGHT_CLIENT).merkle_root();
     }
-
-    function LIGHT_CLIENT() external view returns (address) {
-        return address(light_client);
-    }
-
-    function changeLightClient(address lightclient) external onlySetter {
-        light_client = ILightClient(lightclient);
-    }
-
 }

--- a/contracts/bridge/src/utils/Math.sol
+++ b/contracts/bridge/src/utils/Math.sol
@@ -35,8 +35,4 @@ contract Math {
             pow++;
         }
     }
-
-    function _max(uint x, uint y) internal pure returns (uint z) {
-        return x >= y ? x : y;
-    }
 }

--- a/contracts/bridge/test/test_verify_message_layer.js
+++ b/contracts/bridge/test/test_verify_message_layer.js
@@ -124,7 +124,6 @@ describe("verify message relay tests", () => {
     darwiniaLaneCommitter0 = await LaneMessageCommitter.deploy(sourceChainPos, targetChainPos)
     await darwiniaLaneCommitter0.registry(sourceOutbound.address, sourceInbound.address)
     darwiniaChainCommitter = await ChainMessageCommitter.deploy()
-    await darwiniaChainCommitter.initialize()
     await darwiniaChainCommitter.registry(darwiniaLaneCommitter0.address)
 
     sourceLightClient = await MockDarwiniaLightClient.deploy()

--- a/contracts/bridge/test/test_verify_message_layer.js
+++ b/contracts/bridge/test/test_verify_message_layer.js
@@ -123,7 +123,7 @@ describe("verify message relay tests", () => {
     sourceInbound = await InboundLane.deploy(targetLightClient.address, sourceChainPos, sourceInLanePos, targetChainPos, targetOutLanePos, 0, 0)
     darwiniaLaneCommitter0 = await LaneMessageCommitter.deploy(sourceChainPos, targetChainPos)
     await darwiniaLaneCommitter0.registry(sourceOutbound.address, sourceInbound.address)
-    darwiniaChainCommitter = await ChainMessageCommitter.deploy(sourceChainPos)
+    darwiniaChainCommitter = await ChainMessageCommitter.deploy()
     await darwiniaChainCommitter.initialize()
     await darwiniaChainCommitter.registry(darwiniaLaneCommitter0.address)
 


### PR DESCRIPTION
- Remove changeLightClient interface
- Setter could not deregister lanes/chains config

Related #284 

There are still three things should care:
- Once truth layer do a hardfork, the lanes associated with it will be disabled.
- Serial lane could be disabled from fee-market protocol.
- ChainMessageCommitter could be changed by darwinia governance